### PR TITLE
Return SQLite status code on error

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -8,7 +8,7 @@ rerun the generator, to avoid loosing the changes.
 
 ## How to import
 ```javascript
-import { open, save, DB, Empty } from "https://deno.land/x/sqlite/mod.ts"
+import { open, save, DB, Empty, status } from "https://deno.land/x/sqlite/mod.ts"
 ```
 The above statement lists all the available imports.
 
@@ -102,6 +102,78 @@ DB is no longer used.
 !> Not closing the database may cause you to
 encounter the limit for open database
 connections.
+
+
+## SqliteError
+```javascript
+new SqliteError(message, code)
+```
+Extension over the standard JS Error object
+to also contain class members for error code
+and error code name.
+
+### SqliteError.code
+
+The SQLite result error code,
+see the SQLite docs for more
+information about each error code.
+
+https://www.sqlite.org/rescode.html
+
+Beyond the SQLite error code, this member
+can also contain custom error codes specific
+to this library (starts at 1000).
+
+| JS name          | code |
+|------------------|------|
+| sqliteOk         | 0    |
+| sqliteError      | 1    |
+| sqliteInternal   | 2    |
+| sqlitePerm       | 3    |
+| sqliteAbort      | 4    |
+| sqliteBusy       | 5    |
+| sqliteLocked     | 6    |
+| sqliteNoMem      | 7    |
+| sqliteReadOnly   | 8    |
+| sqliteInterrupt  | 9    |
+| sqliteIOErr      | 10   |
+| sqliteCorrupt    | 11   |
+| sqliteNotFound   | 12   |
+| sqliteFull       | 13   |
+| sqliteCantOpen   | 14   |
+| sqliteProtocol   | 15   |
+| sqliteEmpty      | 16   |
+| sqliteSchema     | 17   |
+| sqliteTooBig     | 18   |
+| sqliteConstraint | 19   |
+| sqliteMismatch   | 20   |
+| sqliteMisuse     | 21   |
+| sqliteNoLFS      | 22   |
+| sqliteAuth       | 23   |
+| sqlietFormat     | 24   |
+| sqliteRange      | 25   |
+| sqliteNotADB     | 26   |
+| sqliteNotice     | 27   |
+| sqliteWarning    | 28   |
+| sqliteRow        | 100  |
+| sqliteDone       | 101  |
+| stmtLimit        | 1000 |
+| noStmt           | 1001 |
+| databaseLimit    | 1002 |
+| noDatabase       | 1003 |
+
+These codes are accessible via
+the exported `status` object.
+
+### SqliteError.codeName
+```javascript
+get codeName()
+```
+String representation
+of the error code number.
+
+For example, if `code` is 19,
+`codeName` would be sqliteConstraint.
 
 
 ## Rows

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -55,6 +55,20 @@ db.query("INSERT INTO people (name, email) VALUES (?, ?)", name, email);
 ?> Queries like `INSERT INTO` don't return any rows. For these queries `.done()`
 is called automatically.
 
+## Error handling
+
+`DB.query` will throw an exception on failure.
+
+```javascript
+try {
+  db.query("NOT A QUERY");
+} catch (error) {
+  console.log(error.message);
+  console.log(error.code);
+  console.log(error.codeName);
+}
+```
+
 ## Copying a Database
 
 You can copy a whole database in memory.

--- a/mod.ts
+++ b/mod.ts
@@ -1,5 +1,7 @@
 import { DB } from "./src/db.js";
 import { Empty } from "./src/rows.js";
+import { status } from "./src/constants.js";
+import SqliteError from "./src/error.js";
 
 /**
  * open
@@ -35,7 +37,7 @@ async function open(path: string, ignoreNotFound=true): Promise<DB> {
 async function save(db: DB, path?: string): Promise<void> {
   path = path || (db as any)._save_path;
   if (!db._open)
-    throw new Error("Database was closed.");
+    throw new SqliteError("Database was closed.");
   // We obtain the data array ourselves to avoid
   // .data() making a copy
   const ptr = db._wasm.get_db_file(db._id);
@@ -44,4 +46,4 @@ async function save(db: DB, path?: string): Promise<void> {
   return Deno.writeFile(path, data);
 }
 
-export { open, save, DB, Empty };
+export { open, save, DB, Empty, status };

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,12 +1,41 @@
-const status = {
-  sqliteOk:      0,
-  sqliteRow:     100,
-  sqliteDone:    101,
-  stmtLimit:     1000,
-  noStmt:        1001,
-  databaseLimit: 1002,
-  noDatabase:    1003,
-};
+const status = Object.freeze({
+  sqliteOk:          0,   // Successful result
+  sqliteError:       1,   // Generic error
+  sqliteInternal:    2,   // Internal logic error in SQLite
+  sqlitePerm:        3,   // Access permission denied
+  sqliteAbort:       4,   // Callback routine requested an abort
+  sqliteBusy:        5,   // The database file is locked
+  sqliteLocked:      6,   // A table in the database is locked
+  sqliteNoMem:       7,   // A malloc() failed
+  sqliteReadOnly:    8,   // Attempt to write a readonly database
+  sqliteInterrupt:   9,   // Operation terminated by sqlite3_interrupt()
+  sqliteIOErr:       10,  // Some kind of disk I/O error occurred
+  sqliteCorrupt:     11,  // The database disk image is malformed
+  sqliteNotFound:    12,  // Unknown opcode in sqlite3_file_control()
+  sqliteFull:        13,  // Insertion failed because database is full
+  sqliteCantOpen:    14,  // Unable to open the database file
+  sqliteProtocol:    15,  // Database lock protocol error
+  sqliteEmpty:       16,  // Internal use only
+  sqliteSchema:      17,  // The database schema changed
+  sqliteTooBig:      18,  // String or BLOB exceeds size limit
+  sqliteConstraint:  19,  // Abort due to constraint violation
+  sqliteMismatch:    20,  // Data type mismatch
+  sqliteMisuse:      21,  // Library used incorrectly
+  sqliteNoLFS:       22,  // Uses OS features not supported on host
+  sqliteAuth:        23,  // Authorization denied
+  sqlietFormat:      24,  // Not used
+  sqliteRange:       25,  // 2nd parameter to sqlite3_bind out of range
+  sqliteNotADB:      26,  // File opened that is not a database file
+  sqliteNotice:      27,  // Notifications from sqlite3_log()
+  sqliteWarning:     28,  // Warnings from sqlite3_log()
+  sqliteRow:         100, // sqlite3_step() has another row ready
+  sqliteDone:        101, // sqlite3_step() has finished executing
+
+  stmtLimit:         1000, // Statement limit was reached: the statement registry is full, no more statements can be opened
+  noStmt:            1001, // Registry entry at this id is empty
+  databaseLimit:     1002, // Database limit was reached: the database registry is full, no more databases can be opened
+  noDatabase:        1003, // Registry entry at this id is empty
+});
 
 const types = {
   integer: 1,
@@ -20,4 +49,4 @@ const values = {
   error: -1,
 };
 
-export default { status, types, values };
+export { status, types, values };

--- a/src/error.js
+++ b/src/error.js
@@ -1,0 +1,86 @@
+import { status } from "./constants.js";
+
+export default class SqliteError extends Error {
+  /**
+   * SqliteError
+   *
+   * Extension over the standard JS Error object
+   * to also contain class members for error code
+   * and error code name.
+   */
+  constructor(message, code) {
+    super(message);
+    this.name = "SqliteError";
+    this.code = code ?? null;
+  }
+
+  /**
+   * SqliteError.code
+   *
+   * The SQLite result error code,
+   * see the SQLite docs for more
+   * information about each error code.
+   *
+   * https://www.sqlite.org/rescode.html
+   *
+   * Beyond the SQLite error code, this member
+   * can also contain custom error codes specific
+   * to this library (starts at 1000).
+   *
+   * | JS name          | code |
+   * |------------------|------|
+   * | sqliteOk         | 0    |
+   * | sqliteError      | 1    |
+   * | sqliteInternal   | 2    |
+   * | sqlitePerm       | 3    |
+   * | sqliteAbort      | 4    |
+   * | sqliteBusy       | 5    |
+   * | sqliteLocked     | 6    |
+   * | sqliteNoMem      | 7    |
+   * | sqliteReadOnly   | 8    |
+   * | sqliteInterrupt  | 9    |
+   * | sqliteIOErr      | 10   |
+   * | sqliteCorrupt    | 11   |
+   * | sqliteNotFound   | 12   |
+   * | sqliteFull       | 13   |
+   * | sqliteCantOpen   | 14   |
+   * | sqliteProtocol   | 15   |
+   * | sqliteEmpty      | 16   |
+   * | sqliteSchema     | 17   |
+   * | sqliteTooBig     | 18   |
+   * | sqliteConstraint | 19   |
+   * | sqliteMismatch   | 20   |
+   * | sqliteMisuse     | 21   |
+   * | sqliteNoLFS      | 22   |
+   * | sqliteAuth       | 23   |
+   * | sqlietFormat     | 24   |
+   * | sqliteRange      | 25   |
+   * | sqliteNotADB     | 26   |
+   * | sqliteNotice     | 27   |
+   * | sqliteWarning    | 28   |
+   * | sqliteRow        | 100  |
+   * | sqliteDone       | 101  |
+   * | stmtLimit        | 1000 |
+   * | noStmt           | 1001 |
+   * | databaseLimit    | 1002 |
+   * | noDatabase       | 1003 |
+   *
+   * These codes are accessible via
+   * the exported `status` object.
+   */
+
+  /**
+   * SqliteError.codeName
+   *
+   * String representation
+   * of the error code number.
+   *
+   * For example, if `code` is 19,
+   * `codeName` would be sqliteConstraint.
+   */
+  get codeName() {
+    return Object.keys(status).find(
+      key => status[key] === this.code
+    );
+  }
+}

--- a/src/rows.js
+++ b/src/rows.js
@@ -1,5 +1,5 @@
 import { getStr } from "./wasm.js";
-import constants from "./constants.js";
+import * as constants from "./constants.js";
 
 export class Rows {
   /**
@@ -52,7 +52,8 @@ export class Rows {
     if (this._done) return { done: true };
     // Load row data and advance statement
     const row = this._get();
-    switch (this._db._wasm.step(this._db._id, this._id)) {
+    const status = this._db._wasm.step(this._db._id, this._id);
+    switch (status) {
       case constants.status.sqliteRow:
         // NO OP
         break;
@@ -60,9 +61,8 @@ export class Rows {
         this.done();
         break;
       default:
-        // TODO: Make more helpful
         this.done();
-        throw new Error("Internal error.");
+        throw this._db._error(status);
         break;
     }
     return { value: row, done: false };

--- a/src/wasm.js
+++ b/src/wasm.js
@@ -1,9 +1,11 @@
+import SqliteError from "./error.js";
+
 // Move string to C
 export function setStr(wasm, str, closure) {
   const bytes = new TextEncoder().encode(str);
   const ptr = wasm.malloc(bytes.length + 1);
   if (ptr === 0)
-    throw new Error("Out of memory.");
+    throw new SqliteError("Out of memory.");
   const mem = new Uint8Array(wasm.memory.buffer, ptr, bytes.length + 1);
   mem.set(bytes);
   mem[bytes.length] = 0; // \0 terminator
@@ -15,7 +17,7 @@ export function setStr(wasm, str, closure) {
 export function setArr(wasm, arr, closure) {
   const ptr = wasm.malloc(arr.length);
   if (ptr === 0)
-    throw new Error("Out of memory.");
+    throw new SqliteError("Out of memory.");
   const mem = new Uint8Array(wasm.memory.buffer, ptr, arr.length);
   mem.set(arr);
   closure(ptr);


### PR DESCRIPTION
When an error occurs, the library will throw an exception.
However, The Error object that is thrown does not contain the actual status code
from Sqlite. This commit addresses this by extending the Error class to
be able to contain an error code member property.

All Sqlite error codes are also provided in constants.js now.
https://www.sqlite.org/c3ref/c_abort.html

No tests for this yet, I could look into that.