### PR TITLE
Update README to reflect second parameter for query method

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ import { open, save } from "https://deno.land/x/sqlite/mod.ts";
 
 // Open a database
 const db = await open("test.db");
-db.query("CREATE TABLE IF NOT EXISTS people (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)");
+db.query("CREATE TABLE IF NOT EXISTS people (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)", []);
 
 const names = ["Peter Parker", "Clark Kent", "Bruce Wayne"];
 
@@ -35,7 +35,7 @@ for (const name of names)
   db.query("INSERT INTO people (name) VALUES (?)", [name]);
 
 // Print out data in table
-for (const [name] of db.query("SELECT name FROM people"))
+for (const [name] of db.query("SELECT name FROM people", []))
   console.log(name);
 
 // Save and close connection


### PR DESCRIPTION
Even if you have no arguments to fill in, you need to provide empty array otherwise you'll get the following error:
```
Expected 2 arguments, but got 1. ts(2554)
<long hash that I assume resolves to file with query method>(110, 14): An argument for 'values' was not provided.
```
Just thought I'd provide this PR to update it to make it clear for first-time viewers of this project like myself.