### PR TITLE
Fix binding of +Infinity, -Infinity, -0, and extremely large number values

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -157,7 +157,7 @@ export class DB {
           value = value ? 1 : 0;
         // fall through
         case "number":
-          if (Math.floor(value) === value) {
+          if (Number.isSafeInteger(value) && !Object.is(value, -0)) {
             status = this._wasm.bind_int(stmt, i + 1, value);
           } else {
             status = this._wasm.bind_double(stmt, i + 1, value);

--- a/src/db.ts
+++ b/src/db.ts
@@ -157,7 +157,7 @@ export class DB {
           value = value ? 1 : 0;
         // fall through
         case "number":
-          if (Number.isSafeInteger(value) && !Object.is(value, -0)) {
+          if (Number.isSafeInteger(value)) {
             status = this._wasm.bind_int(stmt, i + 1, value);
           } else {
             status = this._wasm.bind_double(stmt, i + 1, value);

--- a/test.ts
+++ b/test.ts
@@ -786,3 +786,63 @@ Deno.test("outputToObjectArrayEmpty", function () {
     "Result is not an array or does not have the correct length",
   );
 });
+
+Deno.test("infinitiesAndInfinitesimals", function () {
+  const db = new DB();
+
+  // return
+
+  const [[selectedPositiveInfinity]] = db.query("SELECT +8e8888");
+  assertEquals(
+    selectedPositiveInfinity,
+    +Infinity,
+    "Failed to return correct value for +Infinity.",
+  );
+
+  const [[selectedNegativeInfinity]] = db.query("SELECT -8e8888");
+  assertEquals(
+    selectedNegativeInfinity,
+    -Infinity,
+    "Failed to return correct value for -Infinity.",
+  );
+
+  const [[selectedPositiveZero]] = db.query("SELECT +1/8e8888");
+  assert(
+    Object.is(selectedPositiveZero, +0),
+    "Failed to return correct value for +0.",
+  );
+
+  const [[selectedNegativeZero]] = db.query("SELECT -1/8e8888");
+  assert(
+    Object.is(selectedNegativeZero, -0),
+    "Failed to return correct value for -0.",
+  );
+
+  // bind
+
+  const [[boundPositiveInfinity]] = db.query("SELECT ?", [+Infinity]);
+  assertEquals(
+    boundPositiveInfinity,
+    Infinity,
+    "Failed to bind correct value for +Infinity.",
+  );
+
+  const [[boundNegativeInfinity]] = db.query("SELECT ?", [-Infinity]);
+  assertEquals(
+    boundNegativeInfinity,
+    -Infinity,
+    "Failed to bind correct value for -Infinity.",
+  );
+
+  const [[boundPositiveZero]] = db.query("SELECT ?", [+0]);
+  assert(
+    Object.is(boundPositiveZero, 0),
+    "Failed to bind correct value for +0.",
+  );
+
+  const [[boundNegativeZero]] = db.query("SELECT ?", [-0]);
+  assert(
+    Object.is(boundNegativeZero, -0),
+    "Failed to bind correct value for -0.",
+  );
+});

--- a/test.ts
+++ b/test.ts
@@ -787,7 +787,7 @@ Deno.test("outputToObjectArrayEmpty", function () {
   );
 });
 
-Deno.test("infinitiesAndInfinitesimals", function () {
+Deno.test("veryLargeAndVerySmall", function () {
   const db = new DB();
 
   // return
@@ -818,6 +818,20 @@ Deno.test("infinitiesAndInfinitesimals", function () {
     "Failed to return correct value for -0.",
   );
 
+  const [[selectedPositiveMassive]] = db.query("SELECT +20e20");
+  assertEquals(
+    selectedPositiveMassive,
+    +20e20,
+    "Failed to return correct value for +20e20.",
+  );
+
+  const [[selectedNegativeMassive]] = db.query("SELECT -20e20");
+  assertEquals(
+    selectedNegativeMassive,
+    -20e20,
+    "Failed to return correct value for -20e20.",
+  );
+
   // bind
 
   const [[boundPositiveInfinity]] = db.query("SELECT ?", [+Infinity]);
@@ -844,5 +858,19 @@ Deno.test("infinitiesAndInfinitesimals", function () {
   assert(
     Object.is(boundNegativeZero, -0),
     "Failed to bind correct value for -0.",
+  );
+
+  const [[boundPositiveMassive]] = db.query("SELECT ?", [+20e20]);
+  assertEquals(
+    boundPositiveMassive,
+    +20e20,
+    "Failed to bind correct value for +20e20.",
+  );
+
+  const [[boundNegativeMassive]] = db.query("SELECT ?", [-20e20]);
+  assertEquals(
+    boundNegativeMassive,
+    -20e20,
+    "Failed to bind correct value for -20e20.",
   );
 });

--- a/test.ts
+++ b/test.ts
@@ -787,90 +787,25 @@ Deno.test("outputToObjectArrayEmpty", function () {
   );
 });
 
-Deno.test("veryLargeAndVerySmall", function () {
+Deno.test("veryLargeNumbers", function () {
   const db = new DB();
 
-  // return
+  db.query("CREATE TABLE numbers (id INTEGER PRIMARY KEY, number REAL)");
 
-  const [[selectedPositiveInfinity]] = db.query("SELECT +8e8888");
-  assertEquals(
-    selectedPositiveInfinity,
-    +Infinity,
-    "Failed to return correct value for +Infinity.",
-  );
+  db.query("INSERT INTO numbers (number) VALUES (?)", [+Infinity]);
+  db.query("INSERT INTO numbers (number) VALUES (?)", [-Infinity]);
+  db.query("INSERT INTO numbers (number) VALUES (?)", [+20e20]);
+  db.query("INSERT INTO numbers (number) VALUES (?)", [-20e20]);
 
-  const [[selectedNegativeInfinity]] = db.query("SELECT -8e8888");
-  assertEquals(
-    selectedNegativeInfinity,
-    -Infinity,
-    "Failed to return correct value for -Infinity.",
-  );
+  const [
+    [positiveInfinity],
+    [negativeInfinity],
+    [positiveTwentyTwenty],
+    [negativeTwentyTwenty],
+  ] = db.query("SELECT number FROM numbers");
 
-  const [[selectedPositiveZero]] = db.query("SELECT +1/8e8888");
-  assert(
-    Object.is(selectedPositiveZero, +0),
-    "Failed to return correct value for +0.",
-  );
-
-  const [[selectedNegativeZero]] = db.query("SELECT -1/8e8888");
-  assert(
-    Object.is(selectedNegativeZero, -0),
-    "Failed to return correct value for -0.",
-  );
-
-  const [[selectedPositiveMassive]] = db.query("SELECT +20e20");
-  assertEquals(
-    selectedPositiveMassive,
-    +20e20,
-    "Failed to return correct value for +20e20.",
-  );
-
-  const [[selectedNegativeMassive]] = db.query("SELECT -20e20");
-  assertEquals(
-    selectedNegativeMassive,
-    -20e20,
-    "Failed to return correct value for -20e20.",
-  );
-
-  // bind
-
-  const [[boundPositiveInfinity]] = db.query("SELECT ?", [+Infinity]);
-  assertEquals(
-    boundPositiveInfinity,
-    Infinity,
-    "Failed to bind correct value for +Infinity.",
-  );
-
-  const [[boundNegativeInfinity]] = db.query("SELECT ?", [-Infinity]);
-  assertEquals(
-    boundNegativeInfinity,
-    -Infinity,
-    "Failed to bind correct value for -Infinity.",
-  );
-
-  const [[boundPositiveZero]] = db.query("SELECT ?", [+0]);
-  assert(
-    Object.is(boundPositiveZero, 0),
-    "Failed to bind correct value for +0.",
-  );
-
-  const [[boundNegativeZero]] = db.query("SELECT ?", [-0]);
-  assert(
-    Object.is(boundNegativeZero, -0),
-    "Failed to bind correct value for -0.",
-  );
-
-  const [[boundPositiveMassive]] = db.query("SELECT ?", [+20e20]);
-  assertEquals(
-    boundPositiveMassive,
-    +20e20,
-    "Failed to bind correct value for +20e20.",
-  );
-
-  const [[boundNegativeMassive]] = db.query("SELECT ?", [-20e20]);
-  assertEquals(
-    boundNegativeMassive,
-    -20e20,
-    "Failed to bind correct value for -20e20.",
-  );
+  assertEquals(negativeInfinity, -Infinity);
+  assertEquals(positiveInfinity, +Infinity);
+  assertEquals(positiveTwentyTwenty, +20e20);
+  assertEquals(negativeTwentyTwenty, -20e20);
 });


### PR DESCRIPTION
Closes #89 

Fixes and adds tests the incorrect binding of `+Infinity`, `-Infinity`, `-0`, and extremely-large `number` values, by only binding to `INTEGER` for values which satisfy ` (Number.isSafeInteger(value) && !Object.is(value, -0))`, instead of `(Math.floor(value) === value)`.

In order to be preserve `-0`, we have to bind it as a `REAL` instead of an `INTEGER` like `+0`. As far as I can tell, this should be harmless.

A change in behaviour to call out: integer number values more massive than `MAX_SAFE_INTEGER` which could fit into an `INTEGER` will now be stored as `REAL` instead of `INTEGER`. I could go either way on this, but settled with this because you're usually not supposed to be treating values larger than `MAX_SAFE_INTEGER` as integers, even if they happen to fall on integer values.

If you want to maintain them as `INTEGER`, I think you could change the condition to something like `(Number.isFinite(value) && !Object.is(value, -0) && Math.floor(value) === value && -9_223_372_036_854_775_808 <= value && value <= 9_223_372_036_854_775_807)` instead.
