### PR TITLE
Add tclsh, gcc, and libc6-dev (required to rebuild SQLite) to dev Dockerfile

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -9,4 +9,4 @@ ENV PATH=${DENO_INSTALL}/bin:${PATH} \
     DENO_DIR=${DENO_INSTALL}/.cache/deno
 
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -y install --no-install-recommends fish make
+    && apt-get -y install --no-install-recommends fish make tclsh gcc libc6-dev


### PR DESCRIPTION
As suggested at https://github.com/dyedgreen/deno-sqlite/pull/88#issuecomment-729801045, here is a separate PR updating the dev container Dockerfile to add the dependencies necessary to rebuild SQLite from source. 