### PR TITLE
Log and commit raw and compressed sizes for sqlite.wasm and sqlite.js after building

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -9,4 +9,4 @@ ENV PATH=${DENO_INSTALL}/bin:${PATH} \
     DENO_DIR=${DENO_INSTALL}/.cache/deno
 
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -y install --no-install-recommends fish make tclsh gcc libc6-dev
+    && apt-get -y install --no-install-recommends fish make tclsh gcc libc6-dev brotli

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,9 +14,16 @@ jobs:
       run: |
         export DENO_INSTALL="/home/runner/.deno"
         export PATH="$DENO_INSTALL/bin:$PATH"
-        sudo apt-get -y install --no-install-recommends tclsh gcc
+        sudo apt-get -y install --no-install-recommends tclsh gcc brotli
         cd build
         make setup amalgamation release
+        echo "::group::WASM File Sizes"
+        gzip --best < sqlite.js > sqlite.js.gz
+        gzip --best < sqlite.wasm > sqlite.wasm.gz
+        brotli --best < sqlite.js > sqlite.js.br
+        brotli --best < sqlite.wasm > sqlite.wasm.br
+        ls -l sqlite.* | awk '{printf "%-15s➜%7s bytes\n",$9,$5}'
+        echo "::endgroup::"
     - name: Remove any non tracked build artifacts
       run: |
         cd build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
         export PATH="$DENO_INSTALL/bin:$PATH"
         sudo apt-get -y install --no-install-recommends tclsh gcc brotli
         cd build
-        make setup amalgamation release size.txt
+        make setup amalgamation release
     - name: Remove any non tracked build artifacts
       run: |
         cd build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,14 +16,7 @@ jobs:
         export PATH="$DENO_INSTALL/bin:$PATH"
         sudo apt-get -y install --no-install-recommends tclsh gcc brotli
         cd build
-        make setup amalgamation release
-        echo "::group::WASM File Sizes"
-        gzip --best < sqlite.js > sqlite.js.gz
-        gzip --best < sqlite.wasm > sqlite.wasm.gz
-        brotli --best < sqlite.js > sqlite.js.br
-        brotli --best < sqlite.wasm > sqlite.wasm.br
-        ls -l sqlite.* | awk '{printf "%-15s➜%7s bytes\n",$9,$5}'
-        echo "::endgroup::"
+        make setup amalgamation release size.txt
     - name: Remove any non tracked build artifacts
       run: |
         cd build

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -1,6 +1,7 @@
 name: wasm
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - "master"
@@ -17,9 +18,16 @@ jobs:
       run: |
         export DENO_INSTALL="/home/runner/.deno"
         export PATH="$DENO_INSTALL/bin:$PATH"
-        sudo apt-get -y install --no-install-recommends tclsh gcc
+        sudo apt-get -y install --no-install-recommends tclsh gcc brotli
         cd build
         make setup amalgamation release
+        echo "::group::WASM File Sizes"
+        gzip --best < sqlite.js > sqlite.js.gz
+        gzip --best < sqlite.wasm > sqlite.wasm.gz
+        brotli --best < sqlite.js > sqlite.js.br
+        brotli --best < sqlite.wasm > sqlite.wasm.br
+        ls -l sqlite.* | awk '{printf "%-15s➜%7s bytes\n",$9,$5}'
+        echo "::endgroup::"
     - uses: stefanzweifel/git-auto-commit-action@v2.5.0
       with:
         commit_message: (GitHub Action) Rebuild SQLite WASM

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -20,7 +20,7 @@ jobs:
         export PATH="$DENO_INSTALL/bin:$PATH"
         sudo apt-get -y install --no-install-recommends tclsh gcc brotli
         cd build
-        make setup amalgamation release size.txt
+        make setup amalgamation release
     - uses: stefanzweifel/git-auto-commit-action@v2.5.0
       with:
         commit_message: (GitHub Action) Rebuild SQLite WASM

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -20,14 +20,7 @@ jobs:
         export PATH="$DENO_INSTALL/bin:$PATH"
         sudo apt-get -y install --no-install-recommends tclsh gcc brotli
         cd build
-        make setup amalgamation release
-        echo "::group::WASM File Sizes"
-        gzip --best < sqlite.js > sqlite.js.gz
-        gzip --best < sqlite.wasm > sqlite.wasm.gz
-        brotli --best < sqlite.js > sqlite.js.br
-        brotli --best < sqlite.wasm > sqlite.wasm.br
-        ls -l sqlite.* | awk '{printf "%-15s➜%7s bytes\n",$9,$5}'
-        echo "::endgroup::"
+        make setup amalgamation release size.txt
     - uses: stefanzweifel/git-auto-commit-action@v2.5.0
       with:
         commit_message: (GitHub Action) Rebuild SQLite WASM

--- a/.gitignore
+++ b/.gitignore
@@ -7,8 +7,10 @@ debug.js
 # Misc
 hack.js
 hack.ts
+*.br
 *.db
 *.db-journal
+*.gz
 build/sqlite-src
 build/wasi-sdk
 deno

--- a/build/Makefile
+++ b/build/Makefile
@@ -62,6 +62,13 @@ bundle:
 	$(DENO) run --allow-read --allow-write hack/bundle.js $(OUT_WA) $(OUT_BN)
 	$(DENO) fmt $(OUT_BN)
 
+size.txt: sqlite.js sqlite.wasm
+	gzip --best < sqlite.js > sqlite.js.gz
+	gzip --best < sqlite.wasm > sqlite.wasm.gz
+	brotli --best < sqlite.js > sqlite.js.br
+	brotli --best < sqlite.wasm > sqlite.wasm.br
+	ls -l sqlite.* | awk '{printf "%-15s➜%7s bytes\n",$$9,$$5}' | tee size.txt
+
 debug: FLGS += $(DFLG)
 debug: build
 debug: bundle

--- a/build/Makefile
+++ b/build/Makefile
@@ -63,10 +63,12 @@ bundle:
 	$(DENO) fmt $(OUT_BN)
 
 size.txt: sqlite.js sqlite.wasm
+	rm -f size.txt *.gz *.br
 	gzip --best < sqlite.js > sqlite.js.gz
 	gzip --best < sqlite.wasm > sqlite.wasm.gz
-	brotli --best < sqlite.js > sqlite.js.br
-	brotli --best < sqlite.wasm > sqlite.wasm.br
+	brotli --best -o sqlite.js.br < sqlite.js && \
+	brotli --best -o sqlite.wasm.br < sqlite.wasm || \
+		echo "WARN: brotli size comparison unavailable"
 	ls -l sqlite.* | awk '{printf "%-15s➜%7s bytes\n",$$9,$$5}' | tee size.txt
 
 debug: FLGS += $(DFLG)
@@ -76,6 +78,7 @@ debug: bundle
 release: FLGS += $(RFLG)
 release: build
 release: bundle
+release: size.txt
 
 amalgamation:
 	make -C sqlite-src clean

--- a/build/size.txt
+++ b/build/size.txt
@@ -1,6 +1,4 @@
 sqlite.js      ➜ 857303 bytes
-sqlite.js.br   ➜ 287766 bytes
 sqlite.js.gz   ➜ 349031 bytes
 sqlite.wasm    ➜ 642498 bytes
-sqlite.wasm.br ➜ 226870 bytes
 sqlite.wasm.gz ➜ 266541 bytes

--- a/build/size.txt
+++ b/build/size.txt
@@ -1,0 +1,6 @@
+sqlite.js      ➜ 857303 bytes
+sqlite.js.br   ➜ 287766 bytes
+sqlite.js.gz   ➜ 349031 bytes
+sqlite.wasm    ➜ 642498 bytes
+sqlite.wasm.br ➜ 226870 bytes
+sqlite.wasm.gz ➜ 266541 bytes


### PR DESCRIPTION
To make it easier to assess the size differences between builds, such as is being discussed in https://github.com/dyedgreen/deno-sqlite/pull/109#issuecomment-799163057 and https://github.com/dyedgreen/deno-sqlite/issues/108#issuecomment-794313033, this updates the build actions to log the sizes of `build/sqlite.wasm` and `build/sqlite.js`, raw, gzipped, and brotlied.

Output for current `master` build:
https://github.com/jeremyBanks/deno-sqlite/runs/2114753816?check_suite_focus=true#step:4:2664
```
  sqlite.js      ➜ 857303 bytes
  sqlite.js.br   ➜ 287766 bytes
  sqlite.js.gz   ➜ 349031 bytes
  sqlite.wasm    ➜ 642498 bytes
  sqlite.wasm.br ➜ 226870 bytes
  sqlite.wasm.gz ➜ 266541 bytes
```