### PR TITLE
Add test database generator for CI and local testing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,11 @@ jobs:
         export PATH="$DENO_INSTALL/bin:$PATH"
         sudo apt-get -y install --no-install-recommends tclsh gcc brotli
         cd build
-        make setup amalgamation release testdb
+        make setup amalgamation release
+    - name: Generate Test Database
+      run: |
+        cd build
+        make testdb
     - name: Remove any non tracked build artifacts
       run: |
         cd build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
         export PATH="$DENO_INSTALL/bin:$PATH"
         sudo apt-get -y install --no-install-recommends tclsh gcc brotli
         cd build
-        make setup amalgamation release
+        make setup amalgamation release testdb
     - name: Remove any non tracked build artifacts
       run: |
         cd build

--- a/build/Makefile
+++ b/build/Makefile
@@ -70,6 +70,12 @@ release: FLGS += $(RFLG)
 release: build
 release: bundle
 
+testdb:
+	gcc -Ilib lib/sqlite3.c hack/gen_test_db.c -o gen_test_db
+	rm -f 2GB_test.db
+	./gen_test_db
+	rm gen_test_db
+
 amalgamation:
 	make -C sqlite-src clean
 	make -C sqlite-src sqlite3.c SQLFLG="$(SQLFLG)"

--- a/build/Makefile
+++ b/build/Makefile
@@ -114,7 +114,7 @@ dlwasi:
 	rm "${WASI_TAR}"
 
 testdb:
-	gcc -Ilib lib/sqlite3.c hack/gen_test_db.c -o gen_test_db
+	gcc -Ilib lib/sqlite3.c hack/gen_test_db.c -DSQLITE_THREADSAFE=0 -DSQLITE_OMIT_LOAD_EXTENSION -o gen_test_db
 	rm -f 2GB_test.db
 	./gen_test_db
 	rm gen_test_db

--- a/build/Makefile
+++ b/build/Makefile
@@ -90,12 +90,6 @@ release: bundle
 release: types
 release: size.txt
 
-testdb:
-	gcc -Ilib lib/sqlite3.c hack/gen_test_db.c -o gen_test_db
-	rm -f 2GB_test.db
-	./gen_test_db
-	rm gen_test_db
-
 amalgamation:
 	make -C sqlite-src clean
 	make -C sqlite-src sqlite3.c SQLFLG="$(SQLFLG)"
@@ -118,6 +112,12 @@ dlwasi:
 	tar -xzvf "$(WASI_TAR)"
 	mv "wasi-sdk-11.0" "wasi-sdk"
 	rm "${WASI_TAR}"
+
+testdb:
+	gcc -Ilib lib/sqlite3.c hack/gen_test_db.c -o gen_test_db
+	rm -f 2GB_test.db
+	./gen_test_db
+	rm gen_test_db
 
 setup: dlsqlite
 setup: dlwasi

--- a/build/hack/gen_test_db.c
+++ b/build/hack/gen_test_db.c
@@ -1,0 +1,70 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <sqlite3.h>
+
+#define TEST_DB_FILE "2GB_test.db"
+
+#define SQL_CREATE_TBL "CREATE TABLE test (id INTEGER PRIMARY KEY, value TEXT)"
+#define SQL_INSERT_VAL "INSERT INTO test (value) VALUES (?)"
+
+#define VAL_LEN 65536
+#define VAL_NUM 45000
+
+void rand_str(char *dest, size_t length) {
+  char charset[] = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+  while (length --> 0) {
+    size_t index = (double) rand() / RAND_MAX * (sizeof charset - 1);
+    *dest++ = charset[index];
+  }
+  *dest = '\0';
+}
+
+int main(int argc, char* argv[]) {
+  sqlite3* db;
+  if (sqlite3_open(TEST_DB_FILE, &db) != SQLITE_OK) {
+    printf("Failed to open database: %s\n", sqlite3_errmsg(db));
+    return 1;
+  }
+
+  // create database table
+  sqlite3_stmt* stmt_create;
+  if (sqlite3_prepare_v2(db, SQL_CREATE_TBL, -1, &stmt_create, NULL) != SQLITE_OK) {
+    printf("Failed to prepare create table statement: %s\n", sqlite3_errmsg(db));
+    return 1;
+  }
+  if (sqlite3_step(stmt_create) != SQLITE_DONE) {
+    printf("Failed to run create table statement: %s\n", sqlite3_errmsg(db));
+    return 1;
+  }
+  sqlite3_finalize(stmt_create);
+
+  // insert values to reach 2GB
+  sqlite3_stmt* stmt_insert;
+  if (sqlite3_prepare_v2(db, SQL_INSERT_VAL, -1, &stmt_insert, NULL) != SQLITE_OK) {
+    printf("Failed to prepare insert table statement: %s\n", sqlite3_errmsg(db));
+    return 1;
+  }
+
+  char* buffer = malloc(VAL_LEN + 1);
+  for (int64_t i = 0; i < VAL_NUM; i++) {
+    rand_str(buffer, VAL_LEN);
+    if (sqlite3_bind_text(stmt_insert, 1, buffer, VAL_LEN, NULL) != SQLITE_OK) {
+      printf("Failed to bind value `%s`: %s\n", buffer, sqlite3_errmsg(db));
+      return 1;
+    }
+    if (sqlite3_step(stmt_insert) != SQLITE_DONE) {
+      printf("Failed to run insert statement: %s\n", sqlite3_errmsg(db));
+      return 1;
+    }
+    if (sqlite3_reset(stmt_insert) != SQLITE_OK) {
+      printf("Failed to reset statement: %s\n", sqlite3_errmsg(db));
+      return 1;
+    }
+  }
+  sqlite3_finalize(stmt_insert);
+  sqlite3_close(db);
+
+  printf("Database created successfully.\n");
+
+  return 0;
+}

--- a/test.ts
+++ b/test.ts
@@ -798,18 +798,16 @@ Deno.test("veryLargeNumbers", function () {
 
 Deno.test({
   name: "dbLarger2GB",
-  ignore: !permRead || !permWrite || !(await dbExists("movies.db")),
+  ignore: !permRead || !permWrite || !(await dbExists("./build/2GB_test.db")),
   fn: async function () {
-    // This test needs to write to a very large database file (>2GB)
-    // generating/ downloading this file at test time takes a long time
-    // and so currently this test depends on the file being present in
-    // the system already. To get a copy of the file used visit
-    // https://www.kaggle.com/clementmsika/mubi-sqlite-database-for-movie-lovers
-    //
-    // TODO(dyedgreen): Somehow add large database file to GitHub test container
-    const db = new DB("movies.db");
-    const rand = () => Math.random().toString(36).substring(7);
-    db.query("INSERT INTO ratings (critic) VALUES (?)", [rand()]);
+    const db = new DB("./build/2GB_test.db"); // can be generated with `cd build && make testdb`
+
+    db.query("INSERT INTO test (value) VALUES (?)", ["This is a test..."]);
+
+    let rows = [...db.query("SELECT value FROM test ORDER BY id DESC LIMIT 10")];
+    assertEquals(rows.length, 10);
+    assertEquals(rows[0][0], "This is a test...");
+
     db.close();
   },
 });

--- a/test.ts
+++ b/test.ts
@@ -804,7 +804,9 @@ Deno.test({
 
     db.query("INSERT INTO test (value) VALUES (?)", ["This is a test..."]);
 
-    let rows = [...db.query("SELECT value FROM test ORDER BY id DESC LIMIT 10")];
+    let rows = [
+      ...db.query("SELECT value FROM test ORDER BY id DESC LIMIT 10"),
+    ];
     assertEquals(rows.length, 10);
     assertEquals(rows[0][0], "This is a test...");
 

--- a/test.ts
+++ b/test.ts
@@ -414,67 +414,6 @@ Deno.test({
   },
 });
 
-Deno.test({
-  name: "largeDB",
-  ignore: !permRead || !permWrite,
-  fn: async function () {
-    // Ensure test file does not exist
-    await removeTestDb(testDbFile);
-    const db = new DB(testDbFile);
-
-    // test taken from https://github.com/dyedgreen/deno-sqlite/issues/75
-    db.query(
-      "CREATE TABLE IF NOT EXISTS nos (c1 INTEGER, c2 TEXT, c3 TEXT, c4 TEXT, c5 TEXT, c6 TEXT, c7 INTEGER, c8 TEXT UNIQUE)",
-    );
-
-    const MAX = 100000;
-
-    const xs = [];
-    for (let i = 0; i < MAX; i++) {
-      const a = i * 15000;
-      const b = a % 37;
-      const c = a * b / 41;
-      const d = c + a;
-      const e = (new Date()).getTime() + b - a;
-      const f = b - a;
-      const g = a + e;
-
-      const hash = createHash("sha1");
-      hash.update(`${a}${b}{c}{d}{e}{f}{g}`);
-      const h = hash.toString();
-
-      xs.push({
-        c1: a,
-        c2: `${b}`,
-        c3: `${c}`,
-        c4: `${d}`,
-        c5: `${e}`,
-        c6: `${f}`,
-        c7: g,
-        c8: h,
-      });
-    }
-
-    db.query("begin;");
-    for (let i = 0; i < xs.length; i++) {
-      const n = i + 1;
-      const commit = n % (MAX / 10) === 0;
-      const x = xs[i];
-      db.query(
-        "INSERT OR IGNORE INTO nos(c1, c2, c3, c4, c5, c6, c7, c8) VALUES(?, ?, ?, ?, ?, ?, ?, ?)",
-        [x.c1, x.c2, x.c3, x.c4, x.c5, x.c6, x.c7, x.c8],
-      );
-      if (commit) {
-        db.query("commit;");
-        db.query("begin;");
-      }
-    }
-    db.query("commit;");
-
-    db.close();
-  },
-});
-
 Deno.test("invalidSQL", function () {
   const db = new DB();
   const queries = [


### PR DESCRIPTION
closes #107 

- [x] Generate large (>2GB) database
- [x] Set up tests to check for the generated database and use it in the large DB test case (check the case fails when the error is present!)
- [x] Set up CI to generate the test DB before running the tests