### PR TITLE
Export SqliteError as value

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -1,4 +1,5 @@
 export { DB } from "./src/db.ts";
+export { SqliteError } from "./src/error.ts";
 export { Status } from "./src/constants.ts";
 
 export type { SqliteOptions } from "./src/db.ts";
@@ -10,4 +11,3 @@ export type {
   Row,
   RowObject,
 } from "./src/query.ts";
-export type { SqliteError } from "./src/error.ts";


### PR DESCRIPTION
Currently, a compiler error is produced when trying to use `SqliteError` as a value:

> 'SqliteError' cannot be used as a value because it was exported using 'export type'.deno-ts(1362)

It is useful to provide the export as a value for cases like the following:

```ts
import {DB, SqliteError} from 'https://deno.land/x/sqlite/mod.ts';

/*...*/

try {
  db.query(/*...*/); // or any other import that might throw an instance of `SqliteError`
}
catch (ex) {
  if (ex instanceof SqliteError) {
    // handle SQLite error
  }
  else { /*...*/ }
}
```

This PR exports the class as a value to address this. (It can, of course, still be used as a type.)