### PR TITLE
Add helper for running multiple statements

### DIFF
--- a/build/sqlite.d.ts
+++ b/build/sqlite.d.ts
@@ -19,7 +19,7 @@ export interface Wasm {
   finalize: (stmt: StatementPtr) => number;
   reset: (stmt: StatementPtr) => number;
   clear_bindings: (stmt: StatementPtr) => number;
-  run_multiple: (sql: StringPtr) => number;
+  exec: (sql: StringPtr) => number;
   bind_int: (stmt: StatementPtr, idx: number, value: number) => number;
   bind_double: (stmt: StatementPtr, idx: number, value: number) => number;
   bind_text: (stmt: StatementPtr, idx: number, value: StringPtr) => number;

--- a/build/sqlite.d.ts
+++ b/build/sqlite.d.ts
@@ -19,6 +19,7 @@ export interface Wasm {
   finalize: (stmt: StatementPtr) => number;
   reset: (stmt: StatementPtr) => number;
   clear_bindings: (stmt: StatementPtr) => number;
+  run_multiple: (sql: StringPtr) => number;
   bind_int: (stmt: StatementPtr, idx: number, value: number) => number;
   bind_double: (stmt: StatementPtr, idx: number, value: number) => number;
   bind_text: (stmt: StatementPtr, idx: number, value: StringPtr) => number;

--- a/build/src/wrapper.c
+++ b/build/src/wrapper.c
@@ -107,9 +107,9 @@ int EXPORT(clear_bindings) (sqlite3_stmt* stmt) {
 
 // Execute multiple statements from a single string. This ignores any result
 // rows.
-int EXPORT(run_multiple) (const char* sql) {
+int EXPORT(exec) (const char* sql) {
   last_status = sqlite3_exec(database, sql, NULL, NULL, NULL);
-  debug_printf("ran multiple statements (status %i)\n", last_status);
+  debug_printf("ran exec (status %i)\n", last_status);
   return last_status;
 }
 

--- a/build/src/wrapper.c
+++ b/build/src/wrapper.c
@@ -105,6 +105,14 @@ int EXPORT(clear_bindings) (sqlite3_stmt* stmt) {
   return last_status;
 }
 
+// Execute multiple statements from a single string. This ignores any result
+// rows.
+int EXPORT(run_multiple) (const char* sql) {
+  last_status = sqlite3_exec(database, sql, NULL, NULL, NULL);
+  debug_printf("ran multiple statements (status %i)\n", last_status);
+  return last_status;
+}
+
 // Wrappers for bind statements, these return the status directly
 int EXPORT(bind_int) (sqlite3_stmt* stmt, int idx, double value) {
   // we use double to pass in the value, as JS does not support 64 bit integers,

--- a/src/db.ts
+++ b/src/db.ts
@@ -255,14 +255,32 @@ export class DB {
   }
 
   /**
-   * Run multiple statements from a single string. Ignores any
-   * result rows.
+   * Run multiple semicolon-separated statements from a single
+   * string.
+   *
+   * This method cannot bind any query parameters, and any
+   * result rows are discarded. It is only for running a chunk
+   * of raw SQL; for example, to initialize a database.
+   *
+   * # Examples
+   *
+   * ```typescript
+   * db.execute(`
+   *   CREATE TABLE people (
+   *     id INTEGER PRIMARY KEY AUTOINCREMENT,
+   *     name TEXT,
+   *     age REAL,
+   *     city TEXT
+   *   );
+   *   INSERT INTO people (name, age, city) VALUES ("Peter Parker", 21, "nyc");
+   * `);
+   * ```
    */
-  runMultiple(sql: string) {
-    let status = setStr(
+  execute(sql: string) {
+    const status = setStr(
       this._wasm,
       sql,
-      (ptr) => this._wasm.run_multiple(ptr),
+      (ptr) => this._wasm.exec(ptr),
     );
 
     if (status !== Status.SqliteOk) {

--- a/src/db.ts
+++ b/src/db.ts
@@ -255,6 +255,22 @@ export class DB {
   }
 
   /**
+   * Run multiple statements from a single string. Ignores any
+   * result rows.
+   */
+  runMultiple(sql: string) {
+    let status = setStr(
+      this._wasm,
+      sql,
+      (ptr) => this._wasm.run_multiple(ptr),
+    );
+
+    if (status !== Status.SqliteOk) {
+      throw new SqliteError(this._wasm, status);
+    }
+  }
+
+  /**
    * Run a function within the context of a database
    * transaction. If the function throws an error,
    * the transaction is rolled back. Otherwise, the

--- a/test.ts
+++ b/test.ts
@@ -397,6 +397,9 @@ Deno.test("execute multiple statements", function () {
     `);
   });
 
+  // ...but table `test2` was created before the error
+  assertEquals(db.query("SELECT id FROM test2"), []);
+
   // Syntax error after first valid statement
   assertThrows(() => db.execute("SELECT id FROM test; NOT SQL ANYMORE"));
 

--- a/test.ts
+++ b/test.ts
@@ -377,6 +377,32 @@ Deno.test("execute from prepared query", function () {
   db.close();
 });
 
+Deno.test("execute multiple statements", function () {
+  const db = new DB();
+
+  db.execute(`
+    CREATE TABLE test (id INTEGER PRIMARY KEY AUTOINCREMENT);
+
+    INSERT INTO test (id) VALUES (1);
+    INSERT INTO test (id) VALUES (2);
+    INSERT INTO test (id) VALUES (3);
+  `);
+  assertEquals(db.query("SELECT id FROM test"), [[1], [2], [3]]);
+
+  // Table `test` already exists
+  assertThrows(function () {
+    db.execute(`
+      CREATE TABLE test2 (id INTEGER);
+      CREATE TABLE test (id INTEGER);
+    `);
+  });
+
+  // Syntax error after first valid statement
+  assertThrows(() => db.execute("SELECT id FROM test; NOT SQL ANYMORE"));
+
+  db.close();
+});
+
 Deno.test("blobs are copies", function () {
   const db = new DB();
 


### PR DESCRIPTION
Hello!

I wanted something like Python's [`executescript`](https://docs.python.org/3/library/sqlite3.html#sqlite3.Cursor.executescript) so I looked into porting it.

It turns out that SQLite already has a convenience method for this, [`sqlite3_exec`](https://sqlite.org/c3ref/exec.html).

If this had been in the interface, I would have saved quite a bit of time debugging. So I hope this will be merged eventually!

## Things left to do
* Rebuild the WASM
* Document the method better
* Add test?
* Wrap in `TRANSACTION`?

Python's implementation looks like [this](https://github.com/python/cpython/blob/5b1b9eacb92dd47d10793a8868246df6ea477ed6/Modules/_sqlite/cursor.c#L713-L777). I think it's complicated because of threading. It also runs `COMMIT` first, but I don't think this library has an auto-commit feature.

I didn't commit the WASM myself because my computer didn't make an identical build on `master` and I didn't want to do it wrong.