### PR TITLE
feat: improve ergonomics of single result queries

### DIFF
--- a/src/query.ts
+++ b/src/query.ts
@@ -444,11 +444,11 @@ export class PreparedQuery<
   /**
    * Binds the given parameters to the query and returns exactly one row.
    * If the query does not return exactly one row, an error will be thrown.
-   * 
+   *
    * An options object can be provided as a second argument.
    * If an options object is provided and `options.allowNone` is set to `true`,
    * the behavior chnages:
-   * 
+   *
    * - If only one row is found, it will be returned.
    * - If more than one row is found, an error will be thrown.
    * - If no rows are found, `null` will be returned.


### PR DESCRIPTION
Ref: https://github.com/dyedgreen/deno-sqlite/issues/180

I'm opening this as a draft PR per our [previous discussion](https://github.com/dyedgreen/deno-sqlite/issues/180#issuecomment-1095700334).

---

I thought more about [our discussion regarding backwards compatibility](https://github.com/dyedgreen/deno-sqlite/issues/180#issuecomment-1095669064): it would also be backward-compatible to add a second `options` argument to `query.one/oneEntry` with an option named something like `allowNone` to indicate that `null/undefined` is an acceptable result when no matching row is found (instead of throwing an error). It feels cleaner to me to add some method overload signatures for better type resolution than to add additional public methods just to prevent needing to use `try...catch` statements. An options object also allows for future API expansion in a backward-compatible way, given thoughtful naming.

Note: My initial commit is a draft to demonstrate the concept: I didn't spend too much time thinking about names. Also, I prefer `undefined` over `null` in my own code for "empty", but `null` was suggested in the previous discussion, which is why I used it in the code in this PR. I'd like to hear your thoughts on this as well.

@dyedgreen Feedback on this approach?