### PR TITLE
Add `first` and deprecated `one`

### DIFF
--- a/bench.ts
+++ b/bench.ts
@@ -71,7 +71,7 @@ bench({
 
 /** Performance of select statements (select individually; 10_000). */
 bench({
-  name: "select 10 000 (select one)",
+  name: "select 10 000 (select first)",
   runs: 100,
   func: (b): void => {
     b.start();
@@ -79,7 +79,7 @@ bench({
       "SELECT name, balance FROM users WHERE id = ?",
     );
     for (let id = 1; id <= 10_000; id++) {
-      query.one([id]);
+      query.first([id]);
     }
     b.stop();
   },

--- a/src/query.test.ts
+++ b/src/query.test.ts
@@ -284,13 +284,15 @@ Deno.test("query first from prepared query", function () {
   db.query("CREATE TABLE test (id INTEGER PRIMARY KEY AUTOINCREMENT)");
   db.query("INSERT INTO test (id) VALUES (1), (2), (3)");
 
-  const queryFirst = db.prepareQuery<[number]>(
-    "SELECT id FROM test WHERE id = ?",
-  );
-  assertEquals(queryFirst.first([42]), undefined);
-  assertEquals(queryFirst.first([2]), [2]);
+  const querySingle = db.prepareQuery("SELECT id FROM test WHERE id = ?");
+  assertEquals(querySingle.first([42]), undefined);
+  assertEquals(querySingle.first([2]), [2]);
 
-  queryFirst.finalize();
+  const queryAll = db.prepareQuery("SELECT id FROM test ORDER BY id ASC");
+  assertEquals(queryAll.first(), [1]);
+
+  querySingle.finalize();
+  queryAll.finalize();
   db.close();
 });
 

--- a/src/query.test.ts
+++ b/src/query.test.ts
@@ -105,13 +105,13 @@ Deno.test("omitting a value binds NULL", function () {
     "INSERT INTO test (datum) VALUES (?) RETURNING datum",
   );
 
-  assertEquals([null], insert.one());
-  assertEquals([null], insert.one([]));
-  assertEquals([null], insert.one({}));
+  assertEquals([null], insert.first());
+  assertEquals([null], insert.first([]));
+  assertEquals([null], insert.first({}));
 
   // previously bound values are cleared
   insert.execute(["this is not null"]);
-  assertEquals([null], insert.one());
+  assertEquals([null], insert.first());
 });
 
 Deno.test("prepared query clears bindings before reused", function () {
@@ -279,6 +279,21 @@ Deno.test("query all from prepared query", function () {
   db.close();
 });
 
+Deno.test("query first from prepared query", function () {
+  const db = new DB();
+  db.query("CREATE TABLE test (id INTEGER PRIMARY KEY AUTOINCREMENT)");
+  db.query("INSERT INTO test (id) VALUES (1), (2), (3)");
+
+  const queryFirst = db.prepareQuery<[number]>(
+    "SELECT id FROM test WHERE id = ?",
+  );
+  assertEquals(queryFirst.first([42]), undefined);
+  assertEquals(queryFirst.first([2]), [2]);
+
+  queryFirst.finalize();
+  db.close();
+});
+
 Deno.test("query one from prepared query", function () {
   const db = new DB();
   db.query("CREATE TABLE test (id INTEGER PRIMARY KEY AUTOINCREMENT)");
@@ -287,13 +302,14 @@ Deno.test("query one from prepared query", function () {
   const queryOne = db.prepareQuery<[number]>(
     "SELECT id FROM test WHERE id = ?",
   );
+  assertThrows(() => queryOne.one([42]));
   assertEquals(queryOne.one([2]), [2]);
-  queryOne.finalize();
 
   const queryAll = db.prepareQuery("SELECT id FROM test");
   assertThrows(() => queryAll.one());
-  queryAll.finalize();
 
+  queryOne.finalize();
+  queryAll.finalize();
   db.close();
 });
 
@@ -338,14 +354,10 @@ Deno.test("query entries returns correct object shapes", function () {
   }
   insertQuery.finalize();
 
-  const query = db.prepareQuery("SELECT * FROM test LIMIT ?");
-  assertEquals(rowsOrig, query.allEntries([rowsOrig.length]));
-  assertEquals(rowsOrig[0], query.oneEntry([1]));
-  const rowsIter = [];
-  for (const row of query.iterEntries([rowsOrig.length])) {
-    rowsIter.push(row);
-  }
-  assertEquals(rowsOrig, rowsIter);
+  const query = db.prepareQuery("SELECT * FROM test");
+  assertEquals(rowsOrig, [...query.iterEntries()]);
+  assertEquals(rowsOrig, query.allEntries());
+  assertEquals(rowsOrig[0], query.firstEntry());
   assertEquals(rowsOrig, db.queryEntries("SELECT * FROM test"));
 
   query.finalize();


### PR DESCRIPTION
Remove `one` and add `first`. The previous behavior can roughly be emulated with

```typescript
const row = query.first();
if (!row) throw new Error("Missing row");
```

(This drops the check for returning no more than one row, but that check does not matter in most cases, and when it matters should probably be tested for explicitly)