### PR TITLE
Add API to determine auto commit mode

### DIFF
--- a/build/src/wrapper.c
+++ b/build/src/wrapper.c
@@ -112,6 +112,11 @@ double EXPORT(total_changes) () {
   return (double)sqlite3_total_changes(database);
 }
 
+// Returns whether in auto commit mode
+int EXPORT(autocommit) () {
+  return sqlite3_get_autocommit(database);
+}
+
 // Wraps sqlite3_prepare. Returns statement id.
 sqlite3_stmt* EXPORT(prepare) (const char* sql) {
   // Prepare sqlite statement

--- a/src/db.test.ts
+++ b/src/db.test.ts
@@ -163,6 +163,17 @@ Deno.test("database has correct changes and totalChanges", function () {
   assertEquals(6, db.totalChanges);
 });
 
+Deno.test("autoCommit property reflects database state", function () {
+  const db = new DB();
+  assertEquals(db.autoCommit, true);
+
+  db.query("BEGIN");
+  assertEquals(db.autoCommit, false);
+
+  db.query("ROLLBACK");
+  assertEquals(db.autoCommit, true);
+});
+
 Deno.test("last inserted id", function () {
   const db = new DB();
 

--- a/src/db.ts
+++ b/src/db.ts
@@ -730,4 +730,13 @@ export class DB {
   get totalChanges(): number {
     return this.#wasm.total_changes();
   }
+
+  /**
+   * Returns `true` when in auto commit mode and `false` otherwise.
+   * This corresponds to the SQLite function
+   * `sqlite3_get_autocommit`.
+   */
+  get autoCommit(): boolean {
+    return this.#wasm.autocommit() !== 0;
+  }
 }


### PR DESCRIPTION
Add an `autoCommit` property to `DB` that forwards the result of `sqlite3_get_autocommit`.