### PR TITLE
Clarify which module may bypass permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ db.close();
 If you want something that just works (and is fast), use this library.
 
 Depending on your specific needs, there is also
-[sqlite3](https://github.com/denodrivers/sqlite3), however using this module
+[sqlite3](https://github.com/denodrivers/sqlite3), however using that module
 requires the `--allow-ffi` and `--unstable` flags, which means the database
 connection may bypass e.g. file access permissions.
 


### PR DESCRIPTION
I was initially confused about which module required the `ffi` and `unstable` flags due to the ambiguous use of `this`. Using `that` clearly indicates the other module needs those permissions.