### PR TITLE
DB documentation, execute example code results in error

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -388,7 +388,7 @@ export class DB {
    *     age REAL,
    *     city TEXT
    *   );
-   *   INSERT INTO people (name, age, city) VALUES ("Peter Parker", 21, "nyc");
+   *   INSERT INTO people (name, age, city) VALUES ('Peter Parker', 21, 'nyc');
    * `);
    * ```
    */


### PR DESCRIPTION
In the documentation part of DB (https://deno.land/x/sqlite@v3.8/mod.ts?s=DB) the code segment for execute shows double quotes in the SQLite example statement (https://deno.land/x/sqlite@v3.8/mod.ts?s=DB#method_execute_0).

```INSERT INTO people (name, age, city) VALUES ("Peter Parker", 21, "nyc");```

This will not compile in SQLite as strings require a single quote.