### PR TITLE
Enable 'make setup' to run on MacOS/Arm

### DIFF
--- a/build/.checksums
+++ b/build/.checksums
@@ -1,3 +1,3 @@
 bf6d27027087b3f3ff7dfc305aff4cee28a72e6e  sqlite_dl.zip
-022ae45d50b124b9df68be065d65b9a607923362  wasi_dl_linux.tar.gz
-bc76d264214c21a603fc38adb405622a2fcda8b3  wasi_dl_darwin.tar.gz
+4a4c59dd369651fed34dcaa8b0c3f319bf02c8a8  wasi_dl_linux.tar.gz
+69fe720d453d0ded2e63c68eea344e7e547b2ba4  wasi_dl_darwin.tar.gz

--- a/build/Makefile
+++ b/build/Makefile
@@ -9,10 +9,10 @@ OUT_TY = "sqlite.d.ts"
 SQLITE_DLD = "https://sqlite.org/2023/sqlite-src-3420000.zip"
 SQLITE_DIR = "sqlite-src-3420000"
 
-WASI_DLD = "https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-16/wasi-sdk-16.0-linux.tar.gz"
+WASI_DLD = "https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-21/wasi-sdk-21.0-linux.tar.gz"
 WASI_TAR = wasi_dl_linux.tar.gz
 ifeq ($(shell uname), Darwin)
-	WASI_DLD = "https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-16/wasi-sdk-16.0-macos.tar.gz"
+	WASI_DLD = "https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-21/wasi-sdk-21.0-macos.tar.gz"
 	WASI_TAR = wasi_dl_darwin.tar.gz
 endif
 
@@ -122,7 +122,7 @@ dlwasi:
 	sed -n '/${WASI_TAR}/p' ".checksums" | shasum -c -
 	rm -rf "wasi-sdk"
 	tar -xzvf "$(WASI_TAR)"
-	mv "wasi-sdk-16.0" "wasi-sdk"
+	mv "wasi-sdk-21.0" "wasi-sdk"
 	rm "${WASI_TAR}"
 
 testdb:


### PR DESCRIPTION
Upgrade to the latest WASI SDK (version 21) that provides universal binaries for MacOS. This enables `make setup` to succeed on MacOS with x86 was well as Arm hardware.