### PR TITLE
Fix deprecated APIs warnings

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,5 +31,7 @@ jobs:
       run: /home/runner/.deno/bin/deno test --allow-read --allow-write
     - name: Run tests (unstable)
       run: /home/runner/.deno/bin/deno test --unstable --allow-read --allow-write
+    - name: Run tests (DENO_FUTURE)
+      run: DENO_FUTURE=1 /home/runner/.deno/bin/deno test --unstable --allow-read --allow-write
     - name: Run benchmarks
       run: /home/runner/.deno/bin/deno run bench.ts

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,6 +32,8 @@ jobs:
     - name: Run tests (unstable)
       run: /home/runner/.deno/bin/deno test --unstable --allow-read --allow-write
     - name: Run tests (DENO_FUTURE)
+      run: DENO_FUTURE=1 /home/runner/.deno/bin/deno test --allow-read --allow-write
+    - name: Run tests (DENO_FUTURE and unstable)
       run: DENO_FUTURE=1 /home/runner/.deno/bin/deno test --unstable --allow-read --allow-write
     - name: Run benchmarks
       run: /home/runner/.deno/bin/deno run bench.ts

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ encounter. Note that the `master` branch might contain new or breaking features.
 The versioning guarantee applies only to
 [tagged releases](https://github.com/dyedgreen/deno-sqlite/releases).
 
+This module relies on filesystem APIs stabilized in Deno v1.44. To use it with
+earlier Deno versions, you must pass the `--unstable-fs` flag when running your
+application.
+
 ## Documentation
 
 Documentation is available [Deno Docs](https://deno.land/x/sqlite). There is

--- a/build/vfs.js
+++ b/build/vfs.js
@@ -87,13 +87,7 @@ export default function env(inst) {
     // Sync file data to disk
     js_sync: (rid) => {
       const file = getOpenFile(rid);
-      if (typeof file.rid === "number") {
-        // Uses deprecated Deno.FsFile.rid, which will be removed in Deno 2.0
-        Deno.fdatasyncSync(file.rid);
-      } else {
-        // Support DENO_FUTURE, but requires --unstable-fs
-        file.syncDataSync();
-      }
+      file.syncDataSync();
     },
     // Retrieve the size of the given file
     js_size: (rid) => {

--- a/build/vfs.js
+++ b/build/vfs.js
@@ -5,7 +5,7 @@ const isWindows = Deno.build.os === "windows";
 const OPEN_FILES = [];
 
 function getOpenFile(rid) {
-  const file = OPEN_FILES[rid]
+  const file = OPEN_FILES[rid];
   if (!file) {
     throw new Error(`Resource ID ${rid} does not exist.`);
   }
@@ -90,15 +90,15 @@ export default function env(inst) {
     },
     // Acquire a SHARED or EXCLUSIVE file lock
     js_lock: (rid, exclusive) => {
-      // this is unstable and has issues on Windows ...
-      if (Deno.flockSync && !isWindows) {
+      // this has issues on Windows ...
+      if (!isWindows) {
         getOpenFile(rid).lockSync(exclusive !== 0);
       }
     },
     // Release a file lock
     js_unlock: (rid) => {
-      // this is unstable and has issues on Windows ...
-      if (Deno.funlockSync && !isWindows) {
+      // this has issues on Windows ...
+      if (!isWindows) {
         getOpenFile(rid).unlockSync();
       }
     },


### PR DESCRIPTION
Prepare for Deno 2.0 by migrating off of deprecated APIs. Fixes #255.

~~**Major Caveat**~~

~~With `DENO_FUTURE=1` set, there is no stable sync data operation available as of Deno v1.42. Enabling `DENO_FUTURE` removes access to the `Deno.fdatasyncSync` method, and `Deno.FsFile.syncDataSync` is still unstable. With `DENO_FUTURE=1` enabled, this library will only run with `--unstable-fs` (or `--unstable`).~~

~~Please let me know if you want me to document this caveat in the README or if you'd rather wait for `Deno.FsFile.syncDataSync` to stabilize before merging.~~

**Edit**: this limitation was resolved in Deno v1.44. This branch now successfully runs with `DENO_FUTURE=1`.

Thanks for creating this library! It's really easy to use in my scripts. I'm glad to have a chance to contribute back a little bit!