### PR TITLE
Update Browser Build for Deno 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ There is **experimental** support for using `deno-sqlite` in the browser. You
 can generate a browser compatible module by running:
 
 ```bash
-deno bundle --import-map browser/import_map.json browser/mod.ts [output_bundle_path]
+deno run --allow-run --allow-env --allow-read --allow-write ./browser/bundle.js
 ```
 
 The modules documentation can be seen by running

--- a/browser/bundle.js
+++ b/browser/bundle.js
@@ -1,0 +1,20 @@
+import * as esbuild from 'https://deno.land/x/esbuild@v0.20.1/mod.js'
+import { denoPlugins } from 'jsr:@luca/esbuild-deno-loader@0.9'
+
+esbuild.build({
+  plugins: [
+    ...denoPlugins({
+      configPath: await Deno.realPath('./browser/deno.browser.json'),
+    }),
+  ],
+  entryPoints: [await Deno.realPath('./browser/mod.ts')],
+  outdir: await Deno.realPath('./'),
+  bundle: true,
+  platform: 'browser',
+  format: 'esm',
+  target: 'esnext',
+  minify: true,
+  sourcemap: true,
+  treeShaking: true,
+})
+await esbuild.stop()

--- a/browser/deno.browser.json
+++ b/browser/deno.browser.json
@@ -1,0 +1,5 @@
+{
+    "imports": {
+        "../build/vfs.js": "./vfs.js"
+    }
+}

--- a/browser/import_map.json
+++ b/browser/import_map.json
@@ -1,5 +1,0 @@
-{
-  "imports": {
-    "../build/vfs.js": "../browser/vfs.js"
-  }
-}

--- a/browser/vfs.js
+++ b/browser/vfs.js
@@ -70,8 +70,11 @@ class Buffer {
   }
 }
 
-const indexedDB = window.indexedDB || window.mozIndexedDB ||
-  window.webkitIndexedDB || window.msIndexedDB || window.shimIndexedDB;
+const indexedDB = window.indexedDB ||
+  window.mozIndexedDB ||
+  window.webkitIndexedDB ||
+  window.msIndexedDB ||
+  window.shimIndexedDB;
 
 // Web browser indexedDB database
 const database = new Promise((resolve, reject) => {
@@ -195,13 +198,16 @@ export default function env(inst) {
       return Date.now();
     },
     js_timezone: () => {
-      return (new Date()).getTimezoneOffset();
+      return new Date().getTimezoneOffset();
     },
     js_exists: (path_ptr) => {
       const path = getStr(inst.exports, path_ptr);
       return LOADED_FILES.has(path) ? 1 : 0;
     },
     js_access: (_path_ptr) => 1,
+    js_call_user_func: (func_idx, arg_count) => {
+      inst.functions[func_idx](arg_count);
+    },
   };
 
   return { env };


### PR DESCRIPTION
## TL;DR
- Uses [esbuild-deno-loader](https://jsr.io/@luca/esbuild-deno-loader) as [a replacement](https://stackoverflow.com/questions/76028937/deno-bundle-replacement) for `deno bundle` ([now deprecated](https://deno.com/blog/v2.0-release-candidate#command-line-interface-changes))
- Updates `vfs.js`, which supports the browser build, to be in line with the local build
- Uses `deno.json` to handle import maps ([standard in Deno 2](https://docs.deno.com/runtime/fundamentals/configuration/#dependencies)) for the browser build
- Updates `README.md` in line with the above changes

## Notes for Reviewers
- The formatting changes in `vfs.js` arise from running `deno fmt` against the file